### PR TITLE
Require a space before the parens for "async () => {}".

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ module.exports = {
     'prefer-promise-reject-errors': 'error',
     'quotes': ["error", "single", {avoidEscape: true, allowTemplateLiterals: true}],
     'semi': 'error',
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': ['error', {
+      anonymous: 'never',
+      named: 'never',
+      asyncArrow: 'always',
+    }],
     'wrap-iife': 'error',
   },
 };


### PR DESCRIPTION
This is needed to match existing formatting in triggr_native_components.