### PR TITLE
Enforce parens around any number of arrow function params

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'arrow-parens': 'error',
     'curly': 'error',
     'eqeqeq': 'error',
     'max-len': [
@@ -28,6 +29,5 @@ module.exports = {
       asyncArrow: 'always',
     }],
     'wrap-iife': 'error',
-    'arrow-parens': 'error',
   },
 };


### PR DESCRIPTION
For example,
BAD: user => { ... }
GOOD: (user) => { ... }

http://eslint.org/docs/rules/arrow-parens