### PR TITLE
Enforce strict mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
       named: 'never',
       asyncArrow: 'always',
     }],
+    'strict': 'error',
     'wrap-iife': 'error',
   },
 };


### PR DESCRIPTION
We always want to be in strict mode.

For repositories that use CommonJS modules (`require`, i.e. triggr_api), this rule will require 'use strict'.
For repos that use ECMAScript modules (`import`/`export`, i.e. everyone else), this rule is a noop.