### PR TITLE
Allow unused vars in destructuring expressions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     'no-tabs': 'error',
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'error',
-    'no-unused-vars': ['error', {args: 'none'}],
+    'no-unused-vars': ['error', {args: 'none', ignoreRestSiblings: true}],
     'no-var': 'error',
     'object-curly-spacing': 'error',
     'prefer-promise-reject-errors': 'error',


### PR DESCRIPTION
Use case: `let {a, b, ...rest} = props;` allows easily constructing
an object `rest` that is a copy of `props` with some omitted fields.
But without this setting, eslint complains that `a` and `b` are
unused.

https://github.com/eslint/eslint/issues/4880
https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings